### PR TITLE
Replace status message with message code

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ This repository contains an OpenAg firmware module for reading from the
 Digital Light Intensity Sensor based on BH1750 chip. The module defines 1 output,
 "light\_intensity" on which reading is sent at a rate of no more than 0.5 Hz. The module
 will enter an ERROR state whenever it fails to read from the sensor.
+
+Status Codes
+------------
+
+- "31": Sensor response is invalid

--- a/openag_bh1750.cpp
+++ b/openag_bh1750.cpp
@@ -56,6 +56,6 @@ void Bh1750::readData() {
       status_msg = "";
   } else {
     status_level = ERROR;
-    status_msg = "Sensor response is invalid";
+    status_msg = "31";
   }
 }


### PR DESCRIPTION
This is a short-term fix for status message buffer overflow that simply reduces
the number of bits.